### PR TITLE
add extra_join option

### DIFF
--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -1,6 +1,6 @@
 module CounterCulture
   class Counter
-    CONFIG_OPTIONS = [ :column_names, :counter_cache_name, :delta_column, :foreign_key_values, :touch, :delta_magnitude, :execute_after_commit ]
+    CONFIG_OPTIONS = [ :column_names, :counter_cache_name, :delta_column, :foreign_key_values, :touch, :delta_magnitude, :execute_after_commit, :join ]
     ACTIVE_RECORD_VERSION = Gem.loaded_specs["activerecord"].version
 
     attr_reader :model, :relation, *CONFIG_OPTIONS
@@ -12,6 +12,7 @@ module CounterCulture
       @counter_cache_name = options.fetch(:column_name, "#{model.name.tableize}_count")
       @column_names = options[:column_names]
       @delta_column = options[:delta_column]
+      @join = options[:join]
       @foreign_key_values = options[:foreign_key_values]
       @touch = options.fetch(:touch, false)
       @delta_magnitude = options[:delta_magnitude] || 1

--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -200,7 +200,8 @@ module CounterCulture
           end
 
           joins_sql = "LEFT JOIN #{target_table} AS #{target_table_alias} "\
-            "ON #{source_table}.#{source_table_key} = #{target_table_alias}.#{target_table_key}"
+                      "ON #{source_table}.#{source_table_key} = #{target_table_alias}.#{target_table_key}"
+          joins_sql += " #{counter.join}" if counter.join
           # adds 'type' condition to JOIN clause if the current model is a
           # child in a Single Table Inheritance
           if reflect.active_record.column_names.include?('type') &&


### PR DESCRIPTION
This gives us the ability for parent model lookup when dealing with dynamic column names.

The use case is this one [here](https://github.com/fishbrain/rutilus-api/pull/2858) where I have different counter columns (one for unnamed users other for "full named" users).

It works to have only `column_name: proc { |model| model.follower.full_name? ? :followers_count : :unnamed_followers_count }` but the reset counter job doesn't.